### PR TITLE
Fix AliCloud CI/CD pipeline: StsToken mode, AZ updates, remove SG

### DIFF
--- a/.github/workflows/skill-network-test-alicloud.yml
+++ b/.github/workflows/skill-network-test-alicloud.yml
@@ -142,6 +142,8 @@ jobs:
       - name: Configure Aliyun CLI
         run: |
           aliyun configure set \
+            --profile default \
+            --mode StsToken \
             --access-key-id "$ALIBABACLOUD_ACCESS_KEY_ID" \
             --access-key-secret "$ALIBABACLOUD_ACCESS_KEY_SECRET" \
             --sts-token "$ALIBABACLOUD_SECURITY_TOKEN" \
@@ -317,6 +319,8 @@ jobs:
       - name: Configure Aliyun CLI
         run: |
           aliyun configure set \
+            --profile default \
+            --mode StsToken \
             --access-key-id "$ALIBABACLOUD_ACCESS_KEY_ID" \
             --access-key-secret "$ALIBABACLOUD_ACCESS_KEY_SECRET" \
             --sts-token "$ALIBABACLOUD_SECURITY_TOKEN" \

--- a/skills/ipcalc-for-cloud/scripts/cloud_provider_config.py
+++ b/skills/ipcalc-for-cloud/scripts/cloud_provider_config.py
@@ -61,8 +61,7 @@ CLOUD_PROVIDERS: Dict[str, CloudProviderConfig] = {
         'max_cidr_prefix': 8,
         'min_cidr_prefix': 29,
         'availability_zones': [
-            'cn-hangzhou-a', 'cn-hangzhou-b', 'cn-hangzhou-c',
-            'cn-hangzhou-d', 'cn-hangzhou-e', 'cn-hangzhou-f'
+            'cn-hangzhou-h', 'cn-hangzhou-i', 'cn-hangzhou-j', 'cn-hangzhou-k'
         ],
         'supported_outputs': ['info', 'json', 'aliyun', 'terraform']
     },

--- a/skills/ipcalc-for-cloud/templates/alicloud/terraform.template.tf
+++ b/skills/ipcalc-for-cloud/templates/alicloud/terraform.template.tf
@@ -62,31 +62,6 @@ resource "alicloud_vpc" "vpc" {
 
 {{vSwitchResources}}
 # ========================================
-# Security Group (Example)
-# ========================================
-
-resource "alicloud_security_group" "sg" {
-  security_group_name = "${var.vpc_name}-sg"
-  description         = "Security group for ${var.vpc_name}"
-  vpc_id      = alicloud_vpc.vpc.id
-
-  tags = {
-    Environment = "Production"
-    ManagedBy   = "Terraform"
-  }
-}
-
-# Allow internal communication
-resource "alicloud_security_group_rule" "allow_internal" {
-  type              = "ingress"
-  ip_protocol       = "all"
-  policy            = "accept"
-  port_range        = "-1/-1"
-  security_group_id = alicloud_security_group.sg.id
-  cidr_ip           = var.vpc_cidr
-}
-
-# ========================================
 # Outputs
 # ========================================
 
@@ -103,11 +78,6 @@ output "vpc_name" {
 output "vpc_cidr" {
   description = "CIDR block of the VPC"
   value       = alicloud_vpc.vpc.cidr_block
-}
-
-output "security_group_id" {
-  description = "ID of the Security Group"
-  value       = alicloud_security_group.sg.id
 }
 
 {{vSwitchOutputs}}


### PR DESCRIPTION
## Summary

- **Fix `MissingParameter: SecurityToken`** — Added `--profile default --mode StsToken` to `aliyun configure set` in both CI jobs. Without `--mode StsToken`, the Aliyun CLI treats credentials as plain AK and silently drops the STS token from API requests.
- **Fix `ResourceNotAvailable` on vSwitches** — Updated alicloud availability zones from the retired `cn-hangzhou-a/b/c/d/e/f` to current `cn-hangzhou-h/i/j/k` in `cloud_provider_config.py`.
- **Fix `Forbidden.RAM` on security group** — Removed `alicloud_security_group` and `alicloud_security_group_rule` resources from the Terraform template. The RAM role used by GitHub Actions only has VPC permissions; creating security groups requires `ecs:CreateSecurityGroup` which is outside the intended scope.

## Test plan

- [ ] Trigger the `[Skill] Alibaba Cloud VPC Deployment Test` workflow and verify both Terraform and Aliyun CLI jobs pass
- [ ] Confirm vSwitches are created in `cn-hangzhou-h/i/j/k` zones without `ResourceNotAvailable` errors
- [ ] Confirm no `MissingParameter: SecurityToken` errors in the Aliyun CLI job
- [ ] Confirm Terraform apply completes without `Forbidden.RAM` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)