### PR TITLE
Fix GCP peering failures for spoke 2+: serialise creation and fix validation

### DIFF
--- a/.github/workflows/cli-test-gcp-vpc.yml
+++ b/.github/workflows/cli-test-gcp-vpc.yml
@@ -375,10 +375,10 @@ jobs:
         run: |
           echo "🔍 Validating VPC peering connections..."
 
-          # Wait a bit for peerings to stabilize
+          # Wait for peerings to stabilize
           sleep 10
 
-          # First, list all peerings for debugging
+          # List all peerings for debugging
           echo "All peerings on hub VPC:"
           gcloud compute networks peerings list \
             --network="${{ env.VPC_NAME }}"
@@ -387,14 +387,13 @@ jobs:
             HUB_TO_SPOKE_NAME="hub-to-spoke${spoke_num}"
             SPOKE_TO_HUB_NAME="spoke${spoke_num}-to-hub"
 
-            # Check hub-to-spoke peering
+            # Check hub-to-spoke peering using describe for reliable single-resource lookup
             echo "Checking $HUB_TO_SPOKE_NAME..."
-            HUB_TO_SPOKE_STATUS=$(gcloud compute networks peerings list \
-              --network="${{ env.VPC_NAME }}" --flatten="peerings[]" \
-              --filter="peerings.name=$HUB_TO_SPOKE_NAME" \
-              --format="value(peerings.state)" 2>/dev/null)
+            HUB_TO_SPOKE_STATUS=$(gcloud compute networks peerings describe "$HUB_TO_SPOKE_NAME" \
+              --network="${{ env.VPC_NAME }}" \
+              --format="value(state)" 2>/dev/null || echo "NOT_FOUND")
 
-            if [ -z "$HUB_TO_SPOKE_STATUS" ]; then
+            if [ "$HUB_TO_SPOKE_STATUS" = "NOT_FOUND" ]; then
               echo "❌ Peering $HUB_TO_SPOKE_NAME not found!"
               exit 1
             fi
@@ -408,12 +407,11 @@ jobs:
             # Check spoke-to-hub peering
             SPOKE_VPC="${{ env.VPC_NAME }}-spoke${spoke_num}"
             echo "Checking $SPOKE_TO_HUB_NAME..."
-            SPOKE_TO_HUB_STATUS=$(gcloud compute networks peerings list \
-              --network="$SPOKE_VPC" --flatten="peerings[]" \
-              --filter="peerings.name=$SPOKE_TO_HUB_NAME" \
-              --format="value(peerings.state)" 2>/dev/null)
+            SPOKE_TO_HUB_STATUS=$(gcloud compute networks peerings describe "$SPOKE_TO_HUB_NAME" \
+              --network="$SPOKE_VPC" \
+              --format="value(state)" 2>/dev/null || echo "NOT_FOUND")
 
-            if [ -z "$SPOKE_TO_HUB_STATUS" ]; then
+            if [ "$SPOKE_TO_HUB_STATUS" = "NOT_FOUND" ]; then
               echo "❌ Peering $SPOKE_TO_HUB_NAME not found!"
               exit 1
             fi
@@ -603,10 +601,10 @@ jobs:
         run: |
           echo "🔍 Validating VPC peering connections..."
 
-          # Wait a bit for peerings to stabilize
+          # Wait for peerings to stabilize
           sleep 10
 
-          # First, list all peerings for debugging
+          # List all peerings for debugging
           echo "All peerings on hub VPC:"
           gcloud compute networks peerings list \
             --network="${{ env.VPC_NAME }}"
@@ -615,14 +613,13 @@ jobs:
             HUB_TO_SPOKE_NAME="hub-to-spoke${spoke_num}"
             SPOKE_TO_HUB_NAME="spoke${spoke_num}-to-hub"
 
-            # Check hub-to-spoke peering
+            # Check hub-to-spoke peering using describe for reliable single-resource lookup
             echo "Checking $HUB_TO_SPOKE_NAME..."
-            HUB_TO_SPOKE_STATUS=$(gcloud compute networks peerings list \
-              --network="${{ env.VPC_NAME }}" --flatten="peerings[]" \
-              --filter="peerings.name=$HUB_TO_SPOKE_NAME" \
-              --format="value(peerings.state)" 2>/dev/null)
+            HUB_TO_SPOKE_STATUS=$(gcloud compute networks peerings describe "$HUB_TO_SPOKE_NAME" \
+              --network="${{ env.VPC_NAME }}" \
+              --format="value(state)" 2>/dev/null || echo "NOT_FOUND")
 
-            if [ -z "$HUB_TO_SPOKE_STATUS" ]; then
+            if [ "$HUB_TO_SPOKE_STATUS" = "NOT_FOUND" ]; then
               echo "❌ Peering $HUB_TO_SPOKE_NAME not found!"
               exit 1
             fi
@@ -636,12 +633,11 @@ jobs:
             # Check spoke-to-hub peering
             SPOKE_VPC="${{ env.VPC_NAME }}-spoke${spoke_num}"
             echo "Checking $SPOKE_TO_HUB_NAME..."
-            SPOKE_TO_HUB_STATUS=$(gcloud compute networks peerings list \
-              --network="$SPOKE_VPC" --flatten="peerings[]" \
-              --filter="peerings.name=$SPOKE_TO_HUB_NAME" \
-              --format="value(peerings.state)" 2>/dev/null)
+            SPOKE_TO_HUB_STATUS=$(gcloud compute networks peerings describe "$SPOKE_TO_HUB_NAME" \
+              --network="$SPOKE_VPC" \
+              --format="value(state)" 2>/dev/null || echo "NOT_FOUND")
 
-            if [ -z "$SPOKE_TO_HUB_STATUS" ]; then
+            if [ "$SPOKE_TO_HUB_STATUS" = "NOT_FOUND" ]; then
               echo "❌ Peering $SPOKE_TO_HUB_NAME not found!"
               exit 1
             fi

--- a/skills/ipcalc-for-cloud/scripts/template_processor.py
+++ b/skills/ipcalc-for-cloud/scripts/template_processor.py
@@ -893,6 +893,12 @@ def process_gcp_gcloud_template(template_content: str, data: Dict[str, Any]) -> 
             spoke_peering_creation += f'  --peer-network="${{VPC_NAME}}" \\\n'
             spoke_peering_creation += f'  --auto-create-routes\n\n'
 
+            # GCP route propagation after each peering pair must complete before the
+            # next spoke's hub-side peering can be created on the same hub network.
+            if spoke_idx < len(data['spokeVPCs']):
+                spoke_peering_creation += f'echo "Waiting for peering to stabilize before next spoke..."\n'
+                spoke_peering_creation += f'sleep 10\n\n'
+
     # Replace placeholders
     content = content.replace('{{spokeVPCVariables}}', spoke_vpc_variables)
     content = content.replace('{{subnetCreation}}', subnet_creation)
@@ -1015,6 +1021,7 @@ def process_gcp_terraform_template(template_content: str, data: Dict[str, Any]) 
     spoke_outputs = ''
 
     if data.get('peeringEnabled') and data.get('spokeVPCs'):
+        prev_peering_resource = None
         for spoke_idx, spoke in enumerate(data['spokeVPCs'], 1):
             # Add spoke VPC variables
             spoke_vpc_variables += f'\nvariable "spoke{spoke_idx}_cidr" {{\n'
@@ -1065,11 +1072,15 @@ def process_gcp_terraform_template(template_content: str, data: Dict[str, Any]) 
                     spoke_vpc_resources += f'  }}\n'
                     spoke_vpc_resources += f'}}\n'
 
-            # Add peering from hub to spoke
+            # Add peering from hub to spoke.
+            # GCP only allows one peering operation per network at a time, so each
+            # peering resource depends on the previous to force sequential creation.
             spoke_peering_resources += f'\nresource "google_compute_network_peering" "hub_to_spoke{spoke_idx}" {{\n'
             spoke_peering_resources += f'  name         = "hub-to-spoke{spoke_idx}"\n'
             spoke_peering_resources += f'  network      = google_compute_network.vpc.self_link\n'
             spoke_peering_resources += f'  peer_network = google_compute_network.spoke{spoke_idx}_vpc.self_link\n'
+            if prev_peering_resource:
+                spoke_peering_resources += f'  depends_on   = [{prev_peering_resource}]\n'
             spoke_peering_resources += f'}}\n'
 
             # Add peering from spoke to hub
@@ -1077,7 +1088,10 @@ def process_gcp_terraform_template(template_content: str, data: Dict[str, Any]) 
             spoke_peering_resources += f'  name         = "spoke{spoke_idx}-to-hub"\n'
             spoke_peering_resources += f'  network      = google_compute_network.spoke{spoke_idx}_vpc.self_link\n'
             spoke_peering_resources += f'  peer_network = google_compute_network.vpc.self_link\n'
+            spoke_peering_resources += f'  depends_on   = [google_compute_network_peering.hub_to_spoke{spoke_idx}]\n'
             spoke_peering_resources += f'}}\n'
+
+            prev_peering_resource = f'google_compute_network_peering.spoke{spoke_idx}_to_hub'
 
             # Add spoke outputs
             spoke_outputs += f'\noutput "spoke{spoke_idx}_vpc_name" {{\n'


### PR DESCRIPTION
Three bugs combined to cause spoke 2 (and 3) peerings never reaching ACTIVE:

1. Terraform parallel peering creation: the generated Terraform had no
   depends_on between peering resources, so Terraform created all six peerings
   concurrently. GCP only allows one peering operation per network at a time
   and returns a 400 for subsequent requests, so hub-to-spoke2/3 failed.
   Fix: chain each peering resource with depends_on on the previous one,
   forcing the order: hub_to_spoke1 → spoke1_to_hub → hub_to_spoke2 → …

2. gcloud script timing: after creating spoke1-to-hub, GCP begins route
   propagation on the hub network. Immediately creating hub-to-spoke2 can
   hit a concurrent-operation error that the bash script silently ignores
   (no set -e), leaving spoke2-to-hub permanently INACTIVE.
   Fix: add a sleep 10 between each spoke's peering pair in the generated
   gcloud script.

3. Validation filter/format: both jobs used
   gcloud compute networks peerings list --flatten="peerings[]"
     --filter="peerings.name=X" --format="value(peerings.state)"
   After flattening, the field prefix changes, making the filter and format
   unreliable (empty result treated as "not found").
   Fix: replace with gcloud compute networks peerings describe NAME
     --network=NETWORK --format="value(state)" which targets a single
   resource directly and needs no filtering.

https://claude.ai/code/session_018Kvm1iQYU8DYp8WEcifdv7