### PR TITLE
Fix GCP VPC peering status checks with reliable CSV parsing

### DIFF
--- a/.github/workflows/cli-test-gcp-vpc.yml
+++ b/.github/workflows/cli-test-gcp-vpc.yml
@@ -382,27 +382,41 @@ jobs:
 
           while [ $elapsed -lt $MAX_WAIT ]; do
             echo "--- Peering status at ${elapsed}s ---"
-            gcloud compute networks peerings list --network="$VPC"
+
+            # Fetch all hub peerings as CSV for reliable parsing (avoid --filter which
+            # is unreliable for peering objects synthesized from the network resource)
+            hub_peerings=$(gcloud compute networks peerings list \
+              --network="$VPC" \
+              --format="csv[no-heading](name,state)" 2>/dev/null || true)
+            echo "Hub VPC peerings (name,state):"
+            echo "$hub_peerings"
 
             all_active=true
             for spoke_num in 1 2 3; do
-              # Use peerings list --filter instead of peerings describe (which does not exist)
-              hub_status=$(gcloud compute networks peerings list \
-                --network="$VPC" \
-                --filter="name=hub-to-spoke${spoke_num}" \
-                --format="value(state)" 2>/dev/null)
+              # Parse CSV: strip quotes/spaces/CR, match by peering name
+              hub_status=$(echo "$hub_peerings" | awk -F',' -v name="hub-to-spoke${spoke_num}" '{
+                n=$1; gsub(/["\r ]/, "", n)
+                s=$2; gsub(/["\r ]/, "", s)
+                if (n==name) { print s; exit }
+              }')
+              echo "  hub-to-spoke${spoke_num} state: '${hub_status}'"
               if [ "$hub_status" != "ACTIVE" ]; then
-                echo "hub-to-spoke${spoke_num}: ${hub_status:-NOT_FOUND}"
+                echo "  hub-to-spoke${spoke_num}: ${hub_status:-NOT_FOUND}"
                 all_active=false
               fi
 
               spoke_vpc="${VPC}-spoke${spoke_num}"
-              spoke_status=$(gcloud compute networks peerings list \
+              spoke_peerings=$(gcloud compute networks peerings list \
                 --network="$spoke_vpc" \
-                --filter="name=spoke${spoke_num}-to-hub" \
-                --format="value(state)" 2>/dev/null)
+                --format="csv[no-heading](name,state)" 2>/dev/null || true)
+              spoke_status=$(echo "$spoke_peerings" | awk -F',' -v name="spoke${spoke_num}-to-hub" '{
+                n=$1; gsub(/["\r ]/, "", n)
+                s=$2; gsub(/["\r ]/, "", s)
+                if (n==name) { print s; exit }
+              }')
+              echo "  spoke${spoke_num}-to-hub state: '${spoke_status}'"
               if [ "$spoke_status" != "ACTIVE" ]; then
-                echo "spoke${spoke_num}-to-hub: ${spoke_status:-NOT_FOUND}"
+                echo "  spoke${spoke_num}-to-hub: ${spoke_status:-NOT_FOUND}"
                 all_active=false
               fi
             done
@@ -604,27 +618,41 @@ jobs:
 
           while [ $elapsed -lt $MAX_WAIT ]; do
             echo "--- Peering status at ${elapsed}s ---"
-            gcloud compute networks peerings list --network="$VPC"
+
+            # Fetch all hub peerings as CSV for reliable parsing (avoid --filter which
+            # is unreliable for peering objects synthesized from the network resource)
+            hub_peerings=$(gcloud compute networks peerings list \
+              --network="$VPC" \
+              --format="csv[no-heading](name,state)" 2>/dev/null || true)
+            echo "Hub VPC peerings (name,state):"
+            echo "$hub_peerings"
 
             all_active=true
             for spoke_num in 1 2 3; do
-              # Use peerings list --filter instead of peerings describe (which does not exist)
-              hub_status=$(gcloud compute networks peerings list \
-                --network="$VPC" \
-                --filter="name=hub-to-spoke${spoke_num}" \
-                --format="value(state)" 2>/dev/null)
+              # Parse CSV: strip quotes/spaces/CR, match by peering name
+              hub_status=$(echo "$hub_peerings" | awk -F',' -v name="hub-to-spoke${spoke_num}" '{
+                n=$1; gsub(/["\r ]/, "", n)
+                s=$2; gsub(/["\r ]/, "", s)
+                if (n==name) { print s; exit }
+              }')
+              echo "  hub-to-spoke${spoke_num} state: '${hub_status}'"
               if [ "$hub_status" != "ACTIVE" ]; then
-                echo "hub-to-spoke${spoke_num}: ${hub_status:-NOT_FOUND}"
+                echo "  hub-to-spoke${spoke_num}: ${hub_status:-NOT_FOUND}"
                 all_active=false
               fi
 
               spoke_vpc="${VPC}-spoke${spoke_num}"
-              spoke_status=$(gcloud compute networks peerings list \
+              spoke_peerings=$(gcloud compute networks peerings list \
                 --network="$spoke_vpc" \
-                --filter="name=spoke${spoke_num}-to-hub" \
-                --format="value(state)" 2>/dev/null)
+                --format="csv[no-heading](name,state)" 2>/dev/null || true)
+              spoke_status=$(echo "$spoke_peerings" | awk -F',' -v name="spoke${spoke_num}-to-hub" '{
+                n=$1; gsub(/["\r ]/, "", n)
+                s=$2; gsub(/["\r ]/, "", s)
+                if (n==name) { print s; exit }
+              }')
+              echo "  spoke${spoke_num}-to-hub state: '${spoke_status}'"
               if [ "$spoke_status" != "ACTIVE" ]; then
-                echo "spoke${spoke_num}-to-hub: ${spoke_status:-NOT_FOUND}"
+                echo "  spoke${spoke_num}-to-hub: ${spoke_status:-NOT_FOUND}"
                 all_active=false
               fi
             done


### PR DESCRIPTION
## Summary
Refactored the GCP VPC peering status verification logic to use reliable CSV parsing instead of the unreliable `--filter` flag, which fails for peering objects synthesized from network resources.

## Key Changes
- **Replaced gcloud filter with CSV parsing**: Changed from using `gcloud compute networks peerings list --filter="name=..."` to fetching all peerings as CSV and parsing with `awk` for reliable name matching
- **Improved error handling**: Added `2>/dev/null || true` to gracefully handle command failures and prevent script interruption
- **Enhanced logging**: Added explicit output of peering names and states for better debugging visibility, including quoted state values to catch whitespace issues
- **Applied consistently**: Updated both hub and spoke peering status checks in two separate workflow jobs (lines 382-420 and 604-642)

## Implementation Details
- Peerings are now fetched once per network in CSV format with `--format="csv[no-heading](name,state)"`
- CSV parsing uses `awk` with field separator `,` and removes quotes, spaces, and carriage returns to handle formatting inconsistencies
- State values are now displayed in quotes (e.g., `'ACTIVE'`) to make whitespace issues visible during debugging
- Maintains the same overall logic flow while improving reliability of peering status detection

https://claude.ai/code/session_01FQdtH74oPbnaEDnutNorTx